### PR TITLE
Fix: Corrigido ERRO DE DIGITACAO na chamada do metodo no repositorio.…

### DIFF
--- a/src/main/java/dev/leo/urlShorter/Links/LinkRepository.java
+++ b/src/main/java/dev/leo/urlShorter/Links/LinkRepository.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Repository;
 
 public interface LinkRepository extends JpaRepository<Link, Long> {
 
-    Link findByUrlOriginal(String urlEncurtada);
+    Link findByurlLonga(String urlEncurtada);
 
 
 }

--- a/src/main/java/dev/leo/urlShorter/Links/LinkService.java
+++ b/src/main/java/dev/leo/urlShorter/Links/LinkService.java
@@ -34,7 +34,7 @@ public class LinkService {
 
         public Link obterUrlOrignnal (String urlEncurtada){
             try{
-                return linkRepository.findByUrlOriginal(urlEncurtada);
+                return linkRepository.findByurlLonga(urlEncurtada);
             }catch (Exception erro){
                 throw new RuntimeException("url nao existe");
             }


### PR DESCRIPTION
… Estava sendo chamado findByUrloriginal quando deveria ser findByUrlLonga

Na leitura do LOG de erro dava para ver que o metodo estava sendo passado errado e o proprio InteliJ falava que ele nao conseguia achar o metodo findByUrloriginal.

Pratica a leitura do Log de erro, vai te ajudar bastante a resolver erros assim. Mas qualquer coisa manda mensagem que te ajudo